### PR TITLE
fix: use correct link to repo in gemspec

### DIFF
--- a/bridgetown-plausible.gemspec
+++ b/bridgetown-plausible.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email = ["andrewmcodes@protonmail.com"]
   spec.summary = "Plausible Analytics Plugin for Bridgetown"
   spec.description = "A Liquid tag to add Plausible analytics to your site."
-  spec.homepage = "https://github.com/btrb/#{spec.name}"
+  spec.homepage = "https://github.com/bt-rb/#{spec.name}"
   spec.license = "MIT"
   spec.metadata = {
     "bug_tracker_uri" => "#{spec.homepage}/issues",

--- a/lib/bridgetown-plausible/builder.rb
+++ b/lib/bridgetown-plausible/builder.rb
@@ -5,11 +5,11 @@ module Bridgetown
     class Builder < Bridgetown::Builder
       def build
         liquid_tag "plausible" do |_attributes, tag|
-          render
+          render.html_safe
         end
 
         helper "plausible" do
-          render
+          render.html_safe
         end
       end
 


### PR DESCRIPTION
Fixes #8 which was for fixing the link in the gemspec but that led me to find that the project was actually not working with a recent version of Bridgetown.

`render` calls now have to be safe if they are rendering html otherwise it will output as string.