### PR TITLE
fix: use correct package name in automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ or add manually in `Gemfile`:
 
 ```ruby
 group :bridgetown_plugins do
-  gem "bridgetown-plausible", "~> 0.1.0"
+  gem "bridgetown-plausible", "~> 1.0.2"
 end
 ```
 

--- a/bridgetown.automation.rb
+++ b/bridgetown.automation.rb
@@ -1,8 +1,8 @@
-say_status :plausible, "Installing the bridgetown-plausible-tag plugin..."
+say_status :plausible, "Installing the bridgetown-plausible plugin..."
 
 domain_name = ask("What's your Plausible domain?")
 
-add_bridgetown_plugin "bridgetown-plausible-tag"
+add_bridgetown_plugin "bridgetown-plausible"
 
 append_to_file "bridgetown.config.yml" do
   <<~YAML
@@ -13,4 +13,4 @@ append_to_file "bridgetown.config.yml" do
 end
 
 say_status :plausible, "All set! Double-check the plausible block in your config file and review docs at"
-say_status :plausible, "https://github.com/andrewmcodes/bridgetown-plausible-tag"
+say_status :plausible, "https://github.com/bt-rb/bridgetown-plausible"


### PR DESCRIPTION
Use correct package name in automation and prep for release.

Fixes #6
Fixes #7